### PR TITLE
Add Tachmonite MVP skeleton

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,0 +1,20 @@
+import ChatWidget from '../components/tachmonite/ChatWidget';
+
+interface Params {
+  slug: string;
+}
+
+const BusinessSpace = ({ params }: { params: Params }) => {
+  const { slug } = params;
+  return (
+    <div className="p-4">
+      <div className="bg-neutral-900 rounded-xl p-6 text-white">
+        <h1 className="text-2xl font-bold mb-2">Business: {slug}</h1>
+        <p className="text-gray-400">Our awesome services go here.</p>
+      </div>
+      <ChatWidget businessSlug={slug} />
+    </div>
+  );
+};
+
+export default BusinessSpace;

--- a/app/agents/page.tsx
+++ b/app/agents/page.tsx
@@ -1,0 +1,21 @@
+import AgentStatusCard from '../components/tachmonite/AgentStatusCard';
+
+const AgentsPage = () => {
+  const agents = [
+    { id: 1, name: 'Finance Bot', status: 'IDLE', nextRun: 'Tomorrow' },
+    { id: 2, name: 'Marketing Bot', status: 'RUNNING', nextRun: 'In 2h' },
+    { id: 3, name: 'Support Bot', status: 'IDLE', nextRun: 'In 1h' },
+  ];
+  return (
+    <div className="p-4">
+      <h1 className="text-xl text-white mb-4">Agents Scheduler</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {agents.map((a) => (
+          <AgentStatusCard key={a.id} name={a.name} status={a.status} nextRun={a.nextRun} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AgentsPage;

--- a/app/api/agents/respond/route.ts
+++ b/app/api/agents/respond/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  const { businessSlug, message } = await request.json();
+  // TODO: integrate OpenAI GPT-4
+  const reply = `Echo from ${businessSlug}: ${message}`;
+  return NextResponse.json({ reply });
+}

--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -1,0 +1,32 @@
+const BookingsPage = () => {
+  const bookings = [
+    { id: 1, client: 'Alice', service: 'Cut', date: '2025-01-01', status: 'CONFIRMED' },
+    { id: 2, client: 'Bob', service: 'Color', date: '2025-01-02', status: 'PENDING' },
+  ];
+  return (
+    <div className="p-4">
+      <table className="min-w-full text-white">
+        <thead>
+          <tr className="bg-neutral-900">
+            <th className="p-2 text-left">Client</th>
+            <th className="p-2 text-left">Service</th>
+            <th className="p-2 text-left">Date</th>
+            <th className="p-2 text-left">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {bookings.map((b) => (
+            <tr key={b.id} className="border-b border-neutral-800">
+              <td className="p-2">{b.client}</td>
+              <td className="p-2">{b.service}</td>
+              <td className="p-2">{b.date}</td>
+              <td className="p-2">{b.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default BookingsPage;

--- a/app/components/navbar/Navbar.tsx
+++ b/app/components/navbar/Navbar.tsx
@@ -2,6 +2,7 @@
 
 import { SafeUser } from '@/app/types';
 import Image from 'next/image';
+import Link from 'next/link';
 
 import useRegisterModal from '@/app/hooks/useRegisterModal';
 import useLoginModal from '@/app/hooks/useLoginModal';
@@ -23,9 +24,10 @@ const Navbar: React.FC<NavbarProps> = ({ currentUser }) => {
   const bussinessModal = useSetupBusiness();
   const loginModal = useLoginModal();
   const navBarItems = [
-    { id: 0, name: 'Home', link: '/' },
-    { id: 1, name: 'About', link: '/about' },
-    { id: 2, name: 'Contact', link: '/contact' },
+    { id: 0, name: 'Dashboard', link: '/dashboard' },
+    { id: 1, name: 'Bookings', link: '/bookings' },
+    { id: 2, name: 'Agents', link: '/agents' },
+    { id: 3, name: 'Learn', link: '/courses' },
   ];
 
   const onBusiness = useCallback(() => {
@@ -48,8 +50,17 @@ const Navbar: React.FC<NavbarProps> = ({ currentUser }) => {
             alt="Logo"
           />
         </div>
-        <div>
+        <div className="flex gap-4 items-center">
           <Search />
+          {navBarItems.map((item) => (
+            <Link
+              key={item.id}
+              href={item.link}
+              className="hidden md:block text-sm font-semibold text-gray-300 hover:text-white"
+            >
+              {item.name}
+            </Link>
+          ))}
         </div>
 
         <UserMenu currentUser={currentUser} />

--- a/app/components/tachmonite/AgentStatusCard.tsx
+++ b/app/components/tachmonite/AgentStatusCard.tsx
@@ -1,0 +1,28 @@
+'use client';
+import React from 'react';
+
+interface AgentStatusCardProps {
+  name: string;
+  status: string;
+  nextRun?: string;
+}
+
+const statusColors: Record<string, string> = {
+  IDLE: 'bg-gray-500',
+  RUNNING: 'bg-yellow-400',
+  ERROR: 'bg-red-600',
+};
+
+const AgentStatusCard: React.FC<AgentStatusCardProps> = ({ name, status, nextRun }) => {
+  return (
+    <div className="bg-neutral-900 rounded-xl p-4 shadow text-white">
+      <div className="flex justify-between items-center mb-2">
+        <span>{name}</span>
+        <span className={`px-2 py-1 text-xs rounded ${statusColors[status]}`}>{status}</span>
+      </div>
+      {nextRun && <div className="text-xs text-gray-400">Next run: {nextRun}</div>}
+    </div>
+  );
+};
+
+export default AgentStatusCard;

--- a/app/components/tachmonite/AnalyticsWidget.tsx
+++ b/app/components/tachmonite/AnalyticsWidget.tsx
@@ -1,0 +1,18 @@
+'use client';
+import React from 'react';
+
+interface AnalyticsWidgetProps {
+  metric: string;
+  value: number;
+}
+
+const AnalyticsWidget: React.FC<AnalyticsWidgetProps> = ({ metric, value }) => {
+  return (
+    <div className="bg-neutral-900 rounded-xl p-4 shadow text-white text-center">
+      <div className="text-sm mb-1">{metric}</div>
+      <div className="text-2xl font-bold text-yellow-400">{value}</div>
+    </div>
+  );
+};
+
+export default AnalyticsWidget;

--- a/app/components/tachmonite/BookingSummaryCard.tsx
+++ b/app/components/tachmonite/BookingSummaryCard.tsx
@@ -1,0 +1,17 @@
+'use client';
+import React from 'react';
+
+interface BookingSummaryCardProps {
+  count: number;
+}
+
+const BookingSummaryCard: React.FC<BookingSummaryCardProps> = ({ count }) => {
+  return (
+    <div className="bg-neutral-900 rounded-xl p-4 shadow text-white">
+      <div className="text-sm">Bookings Today</div>
+      <div className="text-3xl font-bold text-yellow-400">{count}</div>
+    </div>
+  );
+};
+
+export default BookingSummaryCard;

--- a/app/components/tachmonite/ChatWidget.tsx
+++ b/app/components/tachmonite/ChatWidget.tsx
@@ -1,0 +1,56 @@
+'use client';
+import React, { useState } from 'react';
+import axios from 'axios';
+
+interface ChatWidgetProps {
+  businessSlug: string;
+}
+
+const ChatWidget: React.FC<ChatWidgetProps> = ({ businessSlug }) => {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<{ text: string; from: 'user' | 'bot' }[]>([]);
+  const [input, setInput] = useState('');
+
+  const sendMessage = async () => {
+    if (!input) return;
+    const userMsg = { text: input, from: 'user' } as const;
+    setMessages((m) => [...m, userMsg]);
+    setInput('');
+    try {
+      const res = await axios.post('/api/agents/respond', { businessSlug, message: input });
+      setMessages((m) => [...m, { text: res.data.reply, from: 'bot' }]);
+    } catch {
+      setMessages((m) => [...m, { text: 'Error', from: 'bot' }]);
+    }
+  };
+
+  return (
+    <>
+      <button
+        className="fixed bottom-5 right-5 bg-yellow-400 text-black p-3 rounded-full shadow"
+        onClick={() => setOpen(!open)}
+      >
+        Chat
+      </button>
+      {open && (
+        <div className="fixed bottom-20 right-5 bg-neutral-900 rounded-xl w-72 h-96 p-3 flex flex-col shadow">
+          <div className="flex-1 overflow-y-auto space-y-2">
+            {messages.map((m, i) => (
+              <div key={i} className={`text-sm ${m.from === 'user' ? 'text-right' : 'text-left'}`}>{m.text}</div>
+            ))}
+          </div>
+          <div className="flex gap-2 mt-2">
+            <input
+              className="flex-1 rounded bg-neutral-800 text-white p-1 text-sm"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+            />
+            <button className="bg-yellow-400 text-black px-2 rounded" onClick={sendMessage}>Send</button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ChatWidget;

--- a/app/components/tachmonite/CourseCard.tsx
+++ b/app/components/tachmonite/CourseCard.tsx
@@ -1,0 +1,19 @@
+'use client';
+import React from 'react';
+
+interface CourseCardProps {
+  title: string;
+  minutes: number;
+}
+
+const CourseCard: React.FC<CourseCardProps> = ({ title, minutes }) => {
+  return (
+    <div className="bg-neutral-900 rounded-xl p-4 shadow text-white">
+      <div className="font-semibold mb-2">{title}</div>
+      <div className="text-xs text-gray-400">{minutes} min video</div>
+      <button className="mt-3 w-full bg-yellow-400 text-black py-1 rounded">Deploy Now</button>
+    </div>
+  );
+};
+
+export default CourseCard;

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -1,0 +1,17 @@
+import CourseCard from '../components/tachmonite/CourseCard';
+
+const CoursesPage = () => {
+  const courses = [
+    { id: 1, title: 'Intro to AI Marketing', minutes: 5 },
+    { id: 2, title: 'Automate Finances', minutes: 7 },
+  ];
+  return (
+    <div className="p-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+      {courses.map((c) => (
+        <CourseCard key={c.id} title={c.title} minutes={c.minutes} />
+      ))}
+    </div>
+  );
+};
+
+export default CoursesPage;

--- a/app/cron/agent-runner/route.ts
+++ b/app/cron/agent-runner/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'edge';
+
+export async function GET() {
+  // mock fetching agents and scheduling next run
+  console.log('Running agents...');
+  return NextResponse.json({ ok: true });
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,22 @@
+import BookingSummaryCard from '../components/tachmonite/BookingSummaryCard';
+import AgentStatusCard from '../components/tachmonite/AgentStatusCard';
+import AnalyticsWidget from '../components/tachmonite/AnalyticsWidget';
+
+const Dashboard = () => {
+  return (
+    <div className="space-y-4 p-4">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <BookingSummaryCard count={5} />
+        <AnalyticsWidget metric="Revenue" value={4200} />
+        <AnalyticsWidget metric="Bookings" value={12} />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <AgentStatusCard name="Finance Bot" status="IDLE" nextRun="Tomorrow" />
+        <AgentStatusCard name="Marketing Bot" status="RUNNING" nextRun="In 2h" />
+        <AgentStatusCard name="Support Bot" status="IDLE" nextRun="In 1h" />
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,3 +78,54 @@ model Reservation {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
   listing Listing @relation(fields: [listingId], references: [id], onDelete: Cascade)
 }
+model Business {
+  id          String   @id @default(cuid())
+  ownerId     String   @unique
+  slug        String   @unique
+  name        String
+  tagline     String?
+  avatarUrl   String?
+  services    Service[]
+  agents      Agent[]
+  reservations Reservation[]
+}
+
+model Service {
+  id          String   @id @default(cuid())
+  businessId  String
+  name        String
+  price       Int
+  business    Business @relation(fields: [businessId], references: [id], onDelete: Cascade)
+}
+
+model Agent {
+  id          String   @id @default(cuid())
+  businessId  String
+  name        String
+  role        AgentRole
+  status      AgentStatus
+  nextRun     DateTime?
+  schedule    String
+  business    Business @relation(fields: [businessId], references: [id], onDelete: Cascade)
+}
+
+model Course {
+  id          String   @id @default(cuid())
+  title       String
+  minutes     Int
+  videoUrl    String
+  summary     String
+}
+
+enum AgentRole {
+  FINANCE
+  MARKETING
+  SUPPORT
+}
+
+enum AgentStatus {
+  IDLE
+  RUNNING
+  ERROR
+}
+


### PR DESCRIPTION
## Summary
- extend prisma schema for Business, Service, Agent and Course models
- implement dashboard and analytic widgets
- add agents scheduler page and mock API routes
- create bookings, courses and public business pages with ChatWidget
- update navbar with links to new pages

## Testing
- `npx prisma migrate dev -n init_tachmonite` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*
- `npx prisma studio` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f8ca3b4d08331ac2366873449b509