### PR TITLE
Implement dashboard and booking pages

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,16 +1,50 @@
 import ChatWidget from '../components/tachmonite/ChatWidget';
+import prisma from '../libs/prismadb';
 
 interface Params {
   slug: string;
 }
 
-const BusinessSpace = ({ params }: { params: Params }) => {
+const BusinessSpace = async ({ params }: { params: Params }) => {
   const { slug } = params;
+  const business = await prisma.business.findUnique({
+    where: { slug },
+    include: { services: true },
+  });
+
+  if (!business) {
+    return <div className="p-4 text-white">Business not found</div>;
+  }
+
   return (
-    <div className="p-4">
-      <div className="bg-neutral-900 rounded-xl p-6 text-white">
-        <h1 className="text-2xl font-bold mb-2">Business: {slug}</h1>
-        <p className="text-gray-400">Our awesome services go here.</p>
+    <div className="p-4 space-y-4">
+      <div className="bg-neutral-900 rounded-xl p-6 text-white flex items-center gap-4">
+        {business.avatarUrl && (
+          <img src={business.avatarUrl} alt={business.name} className="w-16 h-16 rounded-full" />
+        )}
+        <div>
+          <h1 className="text-2xl font-bold mb-1">{business.name}</h1>
+          {business.tagline && <p className="text-sm text-gray-400">{business.tagline}</p>}
+        </div>
+      </div>
+      <div className="bg-neutral-900 rounded-xl p-4 text-white">
+        <h2 className="text-lg font-semibold mb-2">Services</h2>
+        <ul className="space-y-1">
+          {business.services.map((s) => (
+            <li key={s.id} className="flex justify-between">
+              <span>{s.name}</span>
+              <span>${s.price}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="bg-neutral-900 rounded-xl p-4 text-white">
+        <h2 className="text-lg font-semibold mb-2">Book a service</h2>
+        <form className="space-y-2">
+          <input type="date" className="w-full bg-neutral-800 p-1 rounded" />
+          <input type="time" className="w-full bg-neutral-800 p-1 rounded" />
+          <button type="submit" className="bg-yellow-400 text-black px-3 py-1 rounded">Submit</button>
+        </form>
       </div>
       <ChatWidget businessSlug={slug} />
     </div>

--- a/app/api/reservations/[reservationId]/route.ts
+++ b/app/api/reservations/[reservationId]/route.ts
@@ -32,3 +32,36 @@ export async function DELETE(
 
   return NextResponse.json(reservation);
 }
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: IParams }
+) {
+  const currentUser = await getCurrentUser();
+
+  if (!currentUser) {
+    return NextResponse.error();
+  }
+
+  const { reservationId } = params;
+  const body = await request.json();
+
+  const { startDate, startTime } = body;
+
+  if (!reservationId || typeof reservationId !== 'string') {
+    throw new Error('Invalid ID');
+  }
+
+  const reservation = await prisma.reservation.updateMany({
+    where: {
+      id: reservationId,
+      OR: [{ userId: currentUser.id }, { listing: { userId: currentUser.id } }],
+    },
+    data: {
+      startDate,
+      startTime,
+    },
+  });
+
+  return NextResponse.json(reservation);
+}

--- a/app/bookings/BookingsClient.tsx
+++ b/app/bookings/BookingsClient.tsx
@@ -1,0 +1,135 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import axios from 'axios';
+import { toast } from 'react-hot-toast';
+import { SafeReservation } from '../types';
+
+interface BookingsClientProps {
+  bookings: SafeReservation[];
+}
+
+const statusColors: Record<string, string> = {
+  CONFIRMED: 'bg-green-600',
+  PENDING: 'bg-yellow-500',
+  CANCELLED: 'bg-red-600',
+};
+
+const BookingsClient: React.FC<BookingsClientProps> = ({ bookings }) => {
+  const router = useRouter();
+  const [processingId, setProcessingId] = useState('');
+  const [editId, setEditId] = useState('');
+  const [formDate, setFormDate] = useState('');
+  const [formTime, setFormTime] = useState('');
+
+  const onCancel = (id: string) => {
+    setProcessingId(id);
+    axios
+      .delete(`/api/reservations/${id}`)
+      .then(() => {
+        toast.success('Cancelled');
+        router.refresh();
+      })
+      .catch(() => toast.error('Error'))
+      .finally(() => setProcessingId(''));
+  };
+
+  const onReschedule = (id: string) => {
+    setProcessingId(id);
+    axios
+      .patch(`/api/reservations/${id}`, {
+        startDate: formDate,
+        startTime: formTime,
+      })
+      .then(() => {
+        toast.success('Rescheduled');
+        router.refresh();
+        setEditId('');
+      })
+      .catch(() => toast.error('Error'))
+      .finally(() => setProcessingId(''));
+  };
+
+  return (
+    <div className="overflow-x-auto text-white">
+      <table className="min-w-full">
+        <thead>
+          <tr className="bg-neutral-900">
+            <th className="p-2 text-left">Client</th>
+            <th className="p-2 text-left">Service</th>
+            <th className="p-2 text-left">Date</th>
+            <th className="p-2 text-left">Time</th>
+            <th className="p-2 text-left">Status</th>
+            <th className="p-2 text-left">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {bookings.map((b) => (
+            <tr key={b.id} className="border-b border-neutral-800">
+              <td className="p-2">{b.user.name}</td>
+              <td className="p-2">{b.listing.title}</td>
+              <td className="p-2">{new Date(b.startDate).toLocaleDateString()}</td>
+              <td className="p-2">{new Date(b.startTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</td>
+              <td className="p-2">
+                <span className={`px-2 py-1 rounded text-xs ${statusColors[b.status] || 'bg-gray-600'}`}>{b.status}</span>
+              </td>
+              <td className="p-2 space-x-2">
+                {editId === b.id ? (
+                  <>
+                    <input
+                      type="date"
+                      value={formDate}
+                      onChange={(e) => setFormDate(e.target.value)}
+                      className="bg-neutral-800 rounded p-1 text-sm"
+                    />
+                    <input
+                      type="time"
+                      value={formTime}
+                      onChange={(e) => setFormTime(e.target.value)}
+                      className="bg-neutral-800 rounded p-1 text-sm"
+                    />
+                    <button
+                      disabled={processingId === b.id}
+                      onClick={() => onReschedule(b.id)}
+                      className="bg-yellow-400 text-black px-2 py-1 rounded text-xs"
+                    >
+                      Save
+                    </button>
+                    <button
+                      onClick={() => setEditId('')}
+                      className="bg-neutral-700 px-2 py-1 rounded text-xs"
+                    >
+                      Cancel
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <button
+                      onClick={() => {
+                        setEditId(b.id);
+                        setFormDate(b.startDate.slice(0, 10));
+                        setFormTime(new Date(b.startTime).toISOString().slice(11,16));
+                      }}
+                      className="bg-neutral-700 px-2 py-1 rounded text-xs"
+                    >
+                      Reschedule
+                    </button>
+                    <button
+                      disabled={processingId === b.id}
+                      onClick={() => onCancel(b.id)}
+                      className="bg-red-600 px-2 py-1 rounded text-xs"
+                    >
+                      Cancel
+                    </button>
+                  </>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default BookingsClient;

--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -1,31 +1,21 @@
-const BookingsPage = () => {
-  const bookings = [
-    { id: 1, client: 'Alice', service: 'Cut', date: '2025-01-01', status: 'CONFIRMED' },
-    { id: 2, client: 'Bob', service: 'Color', date: '2025-01-02', status: 'PENDING' },
-  ];
+import BookingsClient from './BookingsClient';
+import ClientOnly from '../ClientOnly';
+import getCurrentUser from '../actions/getCurrentUser';
+import getReservations from '../actions/getReservations';
+import { redirect } from 'next/navigation';
+
+const BookingsPage = async () => {
+  const currentUser = await getCurrentUser();
+  if (!currentUser) {
+    redirect('/');
+  }
+
+  const bookings = await getReservations({ authorId: currentUser.id });
+
   return (
-    <div className="p-4">
-      <table className="min-w-full text-white">
-        <thead>
-          <tr className="bg-neutral-900">
-            <th className="p-2 text-left">Client</th>
-            <th className="p-2 text-left">Service</th>
-            <th className="p-2 text-left">Date</th>
-            <th className="p-2 text-left">Status</th>
-          </tr>
-        </thead>
-        <tbody>
-          {bookings.map((b) => (
-            <tr key={b.id} className="border-b border-neutral-800">
-              <td className="p-2">{b.client}</td>
-              <td className="p-2">{b.service}</td>
-              <td className="p-2">{b.date}</td>
-              <td className="p-2">{b.status}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <ClientOnly>
+      <BookingsClient bookings={bookings} />
+    </ClientOnly>
   );
 };
 

--- a/app/business/page.tsx
+++ b/app/business/page.tsx
@@ -1,5 +1,5 @@
-import EmptyState from '@/app/components/EmptyState';
 import ClientOnly from '../ClientOnly';
+import { redirect } from 'next/navigation';
 
 import getCurrentUser from '@/app/actions/getCurrentUser';
 import BusinessClient from './BusinessClient';
@@ -9,21 +9,13 @@ const Business = async () => {
   const currentUser = await getCurrentUser();
 
   if (!currentUser) {
-    return (
-      <ClientOnly>
-        <EmptyState title="Unauthorized" subtitle="Please login" />
-      </ClientOnly>
-    );
+    redirect('/');
   }
 
   const listings = await getListings({ userId: currentUser.id });
 
   if (listings.length === 0) {
-    return (
-      <ClientOnly>
-        <EmptyState title="No Business" subtitle="Have no services" />
-      </ClientOnly>
-    );
+    redirect('/');
   }
 
   return (

--- a/app/components/navbar/Navbar.tsx
+++ b/app/components/navbar/Navbar.tsx
@@ -24,10 +24,10 @@ const Navbar: React.FC<NavbarProps> = ({ currentUser }) => {
   const bussinessModal = useSetupBusiness();
   const loginModal = useLoginModal();
   const navBarItems = [
-    { id: 0, name: 'Dashboard', link: '/dashboard' },
-    { id: 1, name: 'Bookings', link: '/bookings' },
-    { id: 2, name: 'Agents', link: '/agents' },
-    { id: 3, name: 'Learn', link: '/courses' },
+    { id: 0, name: 'Dashboard', link: '/dashboard', auth: true },
+    { id: 1, name: 'Bookings', link: '/bookings', auth: true },
+    { id: 2, name: 'Agents', link: '/agents', auth: false },
+    { id: 3, name: 'Learn', link: '/courses', auth: false },
   ];
 
   const onBusiness = useCallback(() => {
@@ -52,15 +52,17 @@ const Navbar: React.FC<NavbarProps> = ({ currentUser }) => {
         </div>
         <div className="flex gap-4 items-center">
           <Search />
-          {navBarItems.map((item) => (
-            <Link
-              key={item.id}
-              href={item.link}
-              className="hidden md:block text-sm font-semibold text-gray-300 hover:text-white"
-            >
-              {item.name}
-            </Link>
-          ))}
+          {navBarItems
+            .filter((item) => !item.auth || currentUser)
+            .map((item) => (
+              <Link
+                key={item.id}
+                href={item.link}
+                className="hidden md:block text-sm font-semibold text-gray-300 hover:text-white"
+              >
+                {item.name}
+              </Link>
+            ))}
         </div>
 
         <UserMenu currentUser={currentUser} />

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,21 +1,54 @@
+import { redirect } from 'next/navigation';
 import BookingSummaryCard from '../components/tachmonite/BookingSummaryCard';
 import AgentStatusCard from '../components/tachmonite/AgentStatusCard';
 import AnalyticsWidget from '../components/tachmonite/AnalyticsWidget';
+import ClientOnly from '../ClientOnly';
+import prisma from '../libs/prismadb';
+import getCurrentUser from '../actions/getCurrentUser';
 
-const Dashboard = () => {
+const Dashboard = async () => {
+  const currentUser = await getCurrentUser();
+  if (!currentUser) {
+    redirect('/');
+  }
+
+  const today = new Date();
+  const startOfDay = new Date(today.setHours(0, 0, 0, 0));
+  const endOfDay = new Date(today.setHours(23, 59, 59, 999));
+
+  const [bookingsToday, totalBookings, totalClients, revenueAgg, agents] = await Promise.all([
+    prisma.reservation.count({
+      where: { startDate: { gte: startOfDay, lte: endOfDay } },
+    }),
+    prisma.reservation.count(),
+    prisma.user.count(),
+    prisma.reservation.aggregate({ _sum: { totalPrice: true } }),
+    prisma.agent.findMany(),
+  ]);
+
+  const revenue = revenueAgg._sum.totalPrice ?? 0;
+
   return (
-    <div className="space-y-4 p-4">
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <BookingSummaryCard count={5} />
-        <AnalyticsWidget metric="Revenue" value={4200} />
-        <AnalyticsWidget metric="Bookings" value={12} />
+    <ClientOnly>
+      <div className="space-y-4 p-4">
+        <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
+          <BookingSummaryCard count={bookingsToday} />
+          <AnalyticsWidget metric="Revenue" value={revenue} />
+          <AnalyticsWidget metric="Bookings" value={totalBookings} />
+          <AnalyticsWidget metric="Clients" value={totalClients} />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {agents.map((a) => (
+            <AgentStatusCard
+              key={a.id}
+              name={a.name}
+              status={a.status}
+              nextRun={a.nextRun ? a.nextRun.toDateString() : undefined}
+            />
+          ))}
+        </div>
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <AgentStatusCard name="Finance Bot" status="IDLE" nextRun="Tomorrow" />
-        <AgentStatusCard name="Marketing Bot" status="RUNNING" nextRun="In 2h" />
-        <AgentStatusCard name="Support Bot" status="IDLE" nextRun="In 1h" />
-      </div>
-    </div>
+    </ClientOnly>
   );
 };
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,8 @@ html,
 body,
 :root {
   height: 100%;
+  background-color: #1a1a1a;
+  color: #f3f3f3;
 }
 
 .leaflet-bottom,


### PR DESCRIPTION
## Summary
- restrict access to Business, Dashboard and Bookings pages
- extend Dashboard with real stats from database
- add Bookings table with reschedule/cancel actions
- support rescheduling via API patch
- render Business Space details
- show nav items only when logged in
- tweak global dark theme styling

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b7b245088331afbf34a771f19ec1