### PR TITLE
Implement Google login page and enforce auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Database connection
+DATABASE_URL=
+
+# NextAuth configuration
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=
+
+# OAuth Providers
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GITHUB_ID=
+GITHUB_SECRET=

--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -1,4 +1,11 @@
-const BookingsPage = () => {
+import getCurrentUser from '../actions/getCurrentUser';
+import { redirect } from 'next/navigation';
+
+const BookingsPage = async () => {
+  const currentUser = await getCurrentUser();
+  if (!currentUser) {
+    redirect('/login');
+  }
   const bookings = [
     { id: 1, client: 'Alice', service: 'Cut', date: '2025-01-01', status: 'CONFIRMED' },
     { id: 2, client: 'Bob', service: 'Color', date: '2025-01-02', status: 'PENDING' },

--- a/app/business/page.tsx
+++ b/app/business/page.tsx
@@ -4,16 +4,13 @@ import ClientOnly from '../ClientOnly';
 import getCurrentUser from '@/app/actions/getCurrentUser';
 import BusinessClient from './BusinessClient';
 import getListings from '../actions/getListings';
+import { redirect } from 'next/navigation';
 
 const Business = async () => {
   const currentUser = await getCurrentUser();
 
   if (!currentUser) {
-    return (
-      <ClientOnly>
-        <EmptyState title="Unauthorized" subtitle="Please login" />
-      </ClientOnly>
-    );
+    redirect('/login');
   }
 
   const listings = await getListings({ userId: currentUser.id });

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,7 +2,14 @@ import BookingSummaryCard from '../components/tachmonite/BookingSummaryCard';
 import AgentStatusCard from '../components/tachmonite/AgentStatusCard';
 import AnalyticsWidget from '../components/tachmonite/AnalyticsWidget';
 
-const Dashboard = () => {
+import getCurrentUser from '../actions/getCurrentUser';
+import { redirect } from 'next/navigation';
+
+const Dashboard = async () => {
+  const currentUser = await getCurrentUser();
+  if (!currentUser) {
+    redirect('/login');
+  }
   return (
     <div className="space-y-4 p-4">
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { signIn } from 'next-auth/react'
+import { FcGoogle } from 'react-icons/fc'
+import { FieldValues, SubmitHandler, useForm } from 'react-hook-form'
+import Button from '../components/Button'
+import Input from '../components/inputs/Input'
+
+const LoginPage = () => {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const { register, handleSubmit, formState:{errors} } = useForm<FieldValues>({
+    defaultValues: { email: '', password: '' }
+  });
+
+  const onSubmit: SubmitHandler<FieldValues> = (data) => {
+    setIsLoading(true);
+    signIn('credentials', { ...data, redirect: false }).then((callback) => {
+      setIsLoading(false);
+      if (callback?.ok) {
+        router.push('/dashboard');
+      }
+      if (callback?.error) {
+        alert(callback.error);
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-4">
+      <div className="w-full max-w-md space-y-4">
+        <Button
+          label="Sign in with Google"
+          icon={FcGoogle}
+          onClick={() => signIn('google', { callbackUrl: '/dashboard' })}
+        />
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <Input id="email" label="Email" disabled={isLoading} register={register} errors={errors} required />
+          <Input id="password" label="Password" type="password" disabled={isLoading} register={register} errors={errors} required />
+          <Button onClick={handleSubmit(onSubmit)} label="Sign in" />
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default LoginPage

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -53,7 +53,7 @@ export const authOptions: AuthOptions = {
     }),
   ],
   pages: {
-    signIn: '/',
+    signIn: '/login',
   },
   debug: process.env.NODE_ENV === 'development',
   session: {


### PR DESCRIPTION
## Summary
- add new `/login` page with Google and credential sign in
- update NextAuth config to use the new page
- redirect unauthenticated users from dashboard, bookings, and business pages
- provide example `.env` with NextAuth settings

## Testing
- `npx next build` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840b15eaa2c83318b1b2c41d4a5db9a